### PR TITLE
Add an ssh-client for private repo support

### DIFF
--- a/5.6/alpine/Dockerfile
+++ b/5.6/alpine/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update -y && apt-get install -y \
 		zlib1g-dev \
 		libicu-dev \
 		g++ \
+		openssh-client \
 	--no-install-recommends && \
 	rm -r /var/lib/apt/lists/*
 

--- a/5.6/platform/Dockerfile
+++ b/5.6/platform/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update -y && apt-get install -y \
 		zlib1g-dev \
 		libicu-dev \
 		g++ \
+		openssh-client \
 	--no-install-recommends && \
 	curl -sS https://silverstripe.github.io/sspak/install | php -- /usr/local/bin && \
 	curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer && \

--- a/7.1/alpine/Dockerfile
+++ b/7.1/alpine/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update -y && apt-get install -y \
 		zlib1g-dev \
 		libicu-dev \
 		g++ \
+		openssh-client \
 	--no-install-recommends && \
 	rm -r /var/lib/apt/lists/*
 

--- a/7.1/platform/Dockerfile
+++ b/7.1/platform/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update -y && apt-get install -y \
 		zlib1g-dev \
 		libicu-dev \
 		g++ \
+		openssh-client \
 	--no-install-recommends && \
 	curl -sS https://silverstripe.github.io/sspak/install | php -- /usr/local/bin && \
 	curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer && \


### PR DESCRIPTION
It seems private repos needs an ssh client in order to clone them down (I've observed this in CircleCI). This PR adds OpenSSH-client to the image.