### PR TITLE
gd configuration, add apt-get autoremove

### DIFF
--- a/5.6/alpine/Dockerfile
+++ b/5.6/alpine/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update -y && apt-get install -y \
 		g++ \
 		openssh-client \
 	--no-install-recommends && \
+	apt-get autoremove -y && \
 	rm -r /var/lib/apt/lists/*
 
 # Install PHP Extensions
@@ -25,6 +26,7 @@ RUN docker-php-ext-configure intl && \
 	docker-php-ext-configure mysql --with-mysql=mysqlnd && \
 	docker-php-ext-configure mysqli --with-mysqli=mysqlnd && \
 	docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ && \
+	docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \
 	docker-php-ext-install -j$(nproc) \
 		bcmath \
 		intl \

--- a/5.6/platform/Dockerfile
+++ b/5.6/platform/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update -y && apt-get install -y \
 	pecl install imagick-3.4.3 && \
 	apt-get remove -y libmagickwand-dev && \
 	apt-get install -y libmagickwand-6.q16-2 && \
+	apt-get autoremove -y && \
 	rm -r /var/lib/apt/lists/*
 
 # Install PHP Extensions
@@ -32,6 +33,7 @@ RUN docker-php-ext-configure intl && \
 	docker-php-ext-configure mysql --with-mysql=mysqlnd && \
 	docker-php-ext-configure mysqli --with-mysqli=mysqlnd && \
 	docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ && \
+	docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \
 	docker-php-ext-enable xdebug && \
 	docker-php-ext-enable imagick && \
 	sed -i '1 a xdebug.remote_autostart=true' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \

--- a/7.1/alpine/Dockerfile
+++ b/7.1/alpine/Dockerfile
@@ -18,12 +18,14 @@ RUN apt-get update -y && apt-get install -y \
 		g++ \
 		openssh-client \
 	--no-install-recommends && \
+	apt-get autoremove -y && \
 	rm -r /var/lib/apt/lists/*
 
 # Install PHP Extensions
 RUN docker-php-ext-configure intl && \
 	docker-php-ext-configure mysqli --with-mysqli=mysqlnd && \
 	docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ && \
+	docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \
 	docker-php-ext-install -j$(nproc) \
 		bcmath \
 		intl \

--- a/7.1/platform/Dockerfile
+++ b/7.1/platform/Dockerfile
@@ -25,12 +25,14 @@ RUN apt-get update -y && apt-get install -y \
 	pecl install imagick-3.4.3 && \
 	apt-get remove -y libmagickwand-dev && \
 	apt-get install -y libmagickwand-6.q16-2 && \
+	apt-get autoremove -y && \
 	rm -r /var/lib/apt/lists/*
 
 # Install PHP Extensions
 RUN docker-php-ext-configure intl && \
 	docker-php-ext-configure mysqli --with-mysqli=mysqlnd && \
 	docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ && \
+	docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \
 	docker-php-ext-enable xdebug && \
 	docker-php-ext-enable imagick && \
 	sed -i '1 a xdebug.remote_autostart=true' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \

--- a/build.sh
+++ b/build.sh
@@ -9,6 +9,10 @@ do
     do
         echo "### Building brettt89/silverstripe-web:${version}-${platform} ###"
         docker build -t "brettt89/silverstripe-web:${version}-${platform}" "${version}/${platform}"
+        if [ "${platform}" == "platform" ]
+        then
+            docker tag "brettt89/silverstripe-web:${version}-${platform}" "brettt89/silverstripe-web:${version}-ssp"
+        fi
     done
     echo "### Building brettt89/silverstripe-web:${platform}"
     docker build -t "brettt89/silverstripe-web:${platform}" "5.6/${platform}"


### PR DESCRIPTION
Configures GD with freetype and jpeg dir options set. Adds autoremove command to reduce image size. 

Built images ready to go:
```
brettt89/silverstripe-web   5.6-platform        7af9e526679a        2 minutes ago        556MB
brettt89/silverstripe-web   latest              7af9e526679a        2 minutes ago        556MB
brettt89/silverstripe-web   platform            7af9e526679a        2 minutes ago        556MB
brettt89/silverstripe-web   7.1-platform        6d04ec23f400        10 minutes ago       570MB
brettt89/silverstripe-web   5.6-alpine          6c1b4a02e2a0        17 minutes ago       524MB
brettt89/silverstripe-web   alpine              6c1b4a02e2a0        17 minutes ago       524MB
brettt89/silverstripe-web   7.1-alpine          9309399ea2d2        22 minutes ago       539MB
```