### PR TITLE
Hotfix: Bad environment variable in apache config

### DIFF
--- a/build/apache-extras.template
+++ b/build/apache-extras.template
@@ -5,7 +5,7 @@ RUN { \
         echo '  DocumentRoot ${DOCUMENT_ROOT}'; \
         echo '  LogLevel warn'; \
         echo '  ServerSignature Off'; \
-        echo '  <Directory ${ENVVAR}>'; \
+        echo '  <Directory ${DOCUMENT_ROOT}>'; \
         echo '    Options +FollowSymLinks'; \
         echo '    Options -ExecCGI -Includes -Indexes'; \
         echo '    AllowOverride all'; \

--- a/src/5.6/apache/jessie/Dockerfile
+++ b/src/5.6/apache/jessie/Dockerfile
@@ -47,7 +47,7 @@ RUN { \
         echo '  DocumentRoot ${DOCUMENT_ROOT}'; \
         echo '  LogLevel warn'; \
         echo '  ServerSignature Off'; \
-        echo '  <Directory ${ENVVAR}>'; \
+        echo '  <Directory ${DOCUMENT_ROOT}>'; \
         echo '    Options +FollowSymLinks'; \
         echo '    Options -ExecCGI -Includes -Indexes'; \
         echo '    AllowOverride all'; \

--- a/src/5.6/apache/stretch/Dockerfile
+++ b/src/5.6/apache/stretch/Dockerfile
@@ -47,7 +47,7 @@ RUN { \
         echo '  DocumentRoot ${DOCUMENT_ROOT}'; \
         echo '  LogLevel warn'; \
         echo '  ServerSignature Off'; \
-        echo '  <Directory ${ENVVAR}>'; \
+        echo '  <Directory ${DOCUMENT_ROOT}>'; \
         echo '    Options +FollowSymLinks'; \
         echo '    Options -ExecCGI -Includes -Indexes'; \
         echo '    AllowOverride all'; \

--- a/src/7.1/apache/buster/Dockerfile
+++ b/src/7.1/apache/buster/Dockerfile
@@ -47,7 +47,7 @@ RUN { \
         echo '  DocumentRoot ${DOCUMENT_ROOT}'; \
         echo '  LogLevel warn'; \
         echo '  ServerSignature Off'; \
-        echo '  <Directory ${ENVVAR}>'; \
+        echo '  <Directory ${DOCUMENT_ROOT}>'; \
         echo '    Options +FollowSymLinks'; \
         echo '    Options -ExecCGI -Includes -Indexes'; \
         echo '    AllowOverride all'; \

--- a/src/7.1/apache/jessie/Dockerfile
+++ b/src/7.1/apache/jessie/Dockerfile
@@ -47,7 +47,7 @@ RUN { \
         echo '  DocumentRoot ${DOCUMENT_ROOT}'; \
         echo '  LogLevel warn'; \
         echo '  ServerSignature Off'; \
-        echo '  <Directory ${ENVVAR}>'; \
+        echo '  <Directory ${DOCUMENT_ROOT}>'; \
         echo '    Options +FollowSymLinks'; \
         echo '    Options -ExecCGI -Includes -Indexes'; \
         echo '    AllowOverride all'; \

--- a/src/7.1/apache/stretch/Dockerfile
+++ b/src/7.1/apache/stretch/Dockerfile
@@ -47,7 +47,7 @@ RUN { \
         echo '  DocumentRoot ${DOCUMENT_ROOT}'; \
         echo '  LogLevel warn'; \
         echo '  ServerSignature Off'; \
-        echo '  <Directory ${ENVVAR}>'; \
+        echo '  <Directory ${DOCUMENT_ROOT}>'; \
         echo '    Options +FollowSymLinks'; \
         echo '    Options -ExecCGI -Includes -Indexes'; \
         echo '    AllowOverride all'; \

--- a/src/7.2/apache/buster/Dockerfile
+++ b/src/7.2/apache/buster/Dockerfile
@@ -47,7 +47,7 @@ RUN { \
         echo '  DocumentRoot ${DOCUMENT_ROOT}'; \
         echo '  LogLevel warn'; \
         echo '  ServerSignature Off'; \
-        echo '  <Directory ${ENVVAR}>'; \
+        echo '  <Directory ${DOCUMENT_ROOT}>'; \
         echo '    Options +FollowSymLinks'; \
         echo '    Options -ExecCGI -Includes -Indexes'; \
         echo '    AllowOverride all'; \

--- a/src/7.2/apache/stretch/Dockerfile
+++ b/src/7.2/apache/stretch/Dockerfile
@@ -47,7 +47,7 @@ RUN { \
         echo '  DocumentRoot ${DOCUMENT_ROOT}'; \
         echo '  LogLevel warn'; \
         echo '  ServerSignature Off'; \
-        echo '  <Directory ${ENVVAR}>'; \
+        echo '  <Directory ${DOCUMENT_ROOT}>'; \
         echo '    Options +FollowSymLinks'; \
         echo '    Options -ExecCGI -Includes -Indexes'; \
         echo '    AllowOverride all'; \

--- a/src/7.3/apache/buster/Dockerfile
+++ b/src/7.3/apache/buster/Dockerfile
@@ -47,7 +47,7 @@ RUN { \
         echo '  DocumentRoot ${DOCUMENT_ROOT}'; \
         echo '  LogLevel warn'; \
         echo '  ServerSignature Off'; \
-        echo '  <Directory ${ENVVAR}>'; \
+        echo '  <Directory ${DOCUMENT_ROOT}>'; \
         echo '    Options +FollowSymLinks'; \
         echo '    Options -ExecCGI -Includes -Indexes'; \
         echo '    AllowOverride all'; \

--- a/src/7.3/apache/stretch/Dockerfile
+++ b/src/7.3/apache/stretch/Dockerfile
@@ -47,7 +47,7 @@ RUN { \
         echo '  DocumentRoot ${DOCUMENT_ROOT}'; \
         echo '  LogLevel warn'; \
         echo '  ServerSignature Off'; \
-        echo '  <Directory ${ENVVAR}>'; \
+        echo '  <Directory ${DOCUMENT_ROOT}>'; \
         echo '    Options +FollowSymLinks'; \
         echo '    Options -ExecCGI -Includes -Indexes'; \
         echo '    AllowOverride all'; \

--- a/src/7.4/apache/buster/Dockerfile
+++ b/src/7.4/apache/buster/Dockerfile
@@ -47,7 +47,7 @@ RUN { \
         echo '  DocumentRoot ${DOCUMENT_ROOT}'; \
         echo '  LogLevel warn'; \
         echo '  ServerSignature Off'; \
-        echo '  <Directory ${ENVVAR}>'; \
+        echo '  <Directory ${DOCUMENT_ROOT}>'; \
         echo '    Options +FollowSymLinks'; \
         echo '    Options -ExecCGI -Includes -Indexes'; \
         echo '    AllowOverride all'; \

--- a/src/8.0/apache/buster/Dockerfile
+++ b/src/8.0/apache/buster/Dockerfile
@@ -47,7 +47,7 @@ RUN { \
         echo '  DocumentRoot ${DOCUMENT_ROOT}'; \
         echo '  LogLevel warn'; \
         echo '  ServerSignature Off'; \
-        echo '  <Directory ${ENVVAR}>'; \
+        echo '  <Directory ${DOCUMENT_ROOT}>'; \
         echo '    Options +FollowSymLinks'; \
         echo '    Options -ExecCGI -Includes -Indexes'; \
         echo '    AllowOverride all'; \


### PR DESCRIPTION
A bad Environment Variable made its way back into the Apache template for Dockerfiles causing Document root directory to have incorrect indexing settings.

This change reverts Apache template back to using DOCUMENT_ROOT for both Directory and root.

Fixes: #55 